### PR TITLE
Add middleware that loads the production / hashed shadow-cljs JS path

### DIFF
--- a/src/carica/middleware/shadow_js_path.clj
+++ b/src/carica/middleware/shadow_js_path.clj
@@ -1,0 +1,22 @@
+(ns carica.middleware.shadow-js-path
+  (:require [carica.core :refer [load-with]]
+            [clojure.java.io :as io]
+            [clojure.tools.reader :as clj-reader]))
+
+(defn get-js-filename [path-to-manifest]
+  (when-let [res (io/resource path-to-manifest)]
+    (-> res
+        (load-with clj-reader/read)
+        first
+        :output-name)))
+
+(defn app-js-filename
+  [f]
+  (fn [resources]
+    (let [{:keys [path-to-manifest-js js-asset-path] :as cfg-map} (f resources)]
+      (if-let [main-js (get-js-filename (or path-to-manifest-js
+                                            "public/js/manifest.edn"))]
+        (let [js-path (str (or js-asset-path "/js/") main-js)]
+          (-> cfg-map
+              (assoc :compiled-js-path js-path)))
+        cfg-map))))


### PR DESCRIPTION
Opening this to get thoughts on the idea of adding something like this directly to Carica. You'll pretty much always need this when building Clojurescript applications with shadow-cljs.

This will read the manifest.edn generated by shadow-cljs and add the key to `(config :compiled-js-path)`. That way in our server side template we can do this:

```clojure
[:body
      [:div#app]
      (hiccup/include-js (config :compiled-js-path))]
```

It's handy to have this stored in the config because we only want to read it once when the server starts up and then rely on the cached version for every other request.

It'll mostly be a drop-in middleware for folks using Shadow, but you can configure your static JS path and path to manifest.edn.

I'll add tests and docs if we think this is appropriate.