### PR TITLE
Add a middleware to convert and merge environment variables into the cfg-map

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject leathekd/carica "1.3.2-SNAPSHOT"
+(defproject leathekd/carica "1.3.3-SNAPSHOT"
   :description "A flexible configuration library"
   :url "https://github.com/leathekd/carica"
   :license {:name "Eclipse Public License"

--- a/src/carica/middleware/system_env.clj
+++ b/src/carica/middleware/system_env.clj
@@ -1,0 +1,72 @@
+(ns carica.middleware.system-env
+  (:require [clojure.edn :as edn]
+            [clojure.string :as string]))
+
+(defn str->num [s]
+  "Convert numeric string into `java.lang.Long` or `clojure.lang.BigInt`"
+  (try
+    (Long/parseLong s)
+    (catch NumberFormatException _
+      (bigint s))))
+
+(defn str->value [v]
+  (cond
+    (re-matches #"[0-9]+" v) (str->num v)
+    (re-matches #"^(true|false)$" v) (Boolean/parseBoolean v)
+    (re-matches #"\w+" v) v
+    :else
+    (try
+      (let [parsed (edn/read-string {:readers *data-readers*} v)]
+        (if (symbol? parsed)
+          v
+          parsed))
+      (catch Throwable _
+        v))))
+
+(defn k->path
+  [k dash level]
+  (as-> k $
+    (string/lower-case $)
+    (string/split $ level)
+    (map (comp keyword #(string/replace % dash "-")) $)))
+
+(defn contains-in?
+  "Checks whether `path` exists within `m`.
+  An empty path always returns true which is akin to the behavior of `get-in`."
+  [m [first & rest :as path]]
+  (if (empty? path)
+    true
+    (and (contains? m first) (contains-in? (get m first) rest))))
+
+(defn substitute [cfg-map [k-path v]]
+  (if (and (seq k-path)
+           (contains-in? cfg-map k-path))
+    (assoc-in cfg-map k-path v)
+    cfg-map))
+
+(defn load-system-env
+  "This middleware converts system environment variables into a map
+  who's values are merged into the main config IF the path exists
+
+  ex:
+
+  export BONE_SAW=\"ready!\"
+
+  ((load-system-env identity) {:bone-saw \"not ready!\"})
+  => {:bone-saw \"ready!\"}
+
+  Environment variables are converted to lower-case and dasherized.
+  Environment variables can map to nested values in the config map by
+  separating keys with 2 underscore characters ex:
+
+  MY__NESTED__VALUE=\"nice\" => {:my {:nested {:value \"nice\"}}}"
+  ([] (load-system-env (System/getenv)))
+  ([env]
+   (fn [f]
+     (fn [resources]
+       (let [cfg-map (f resources)
+             sys-map (->> env
+                          (map (fn [[k v]] [(k->path k "_" #"__")
+                                            (str->value v)]))
+                          (into {}))]
+         (reduce substitute cfg-map sys-map))))))

--- a/test/carica/test/middleware/system_env.clj
+++ b/test/carica/test/middleware/system_env.clj
@@ -1,0 +1,33 @@
+(ns carica.test.middleware.system-env
+  (:require [carica.core :refer [configurer resources]]
+            [carica.middleware.system-env :as senv]
+            [clojure.test :refer :all]))
+
+(deftest load-system-env
+  (testing "it only uses environment variables who's path is present in the config map"
+    (let [cfg-map {:bone-saw "not ready!"}
+          sys-env {"BONE_SAW" "ready!" "NEED_COFFEE" "false"}
+          result (((senv/load-system-env sys-env) identity) cfg-map)]
+      (is (= result {:bone-saw "ready!"}))))
+
+  (testing "it converts environment variables containing __ into nested config values"
+    (let [cfg-map {:bone {:saw "not ready!"}}
+          sys-env {"BONE__SAW" "ready!" "NEED__COFFEE" "false"}
+          result (((senv/load-system-env sys-env) identity) cfg-map)]
+      (is (= result {:bone {:saw "ready!"}}))))
+
+  (testing "it converts boolean and numerical values"
+    (let [cfg-map {:bone {:saw nil}
+                   :need {:coffee nil}}
+          sys-env {"BONE__SAW" "1" "NEED__COFFEE" "false"}
+          result (((senv/load-system-env sys-env) identity) cfg-map)]
+      (is (= result {:bone {:saw 1}
+                     :need {:coffee false}}))))
+
+  (testing "it works as middleware"
+    (let [test-config (configurer
+                       (resources "config.clj")
+                       [(senv/load-system-env {"NESTED_MULTI_CLJ__TEST_CLJ__TEST_CLJ" "new value"
+                                               "FROM_TEST" "yep!"})])]
+      (is (= "new value" (test-config :nested-multi-clj :test-clj :test-clj)))
+      (is (= "yep!" (test-config :from-test))))))


### PR DESCRIPTION
Adds a middleware that converts environment variables into config map values. The tests demonstrate how it works but it will only use environment variables that exist in the config map ex:

`resources/config.edn`
```clojure
{:vault-token nil
 :some-count 0
 :a {:nested {:value false}
```

My environment:
```bash
export VAULT_TOKEN="top secret"
export A__NESTED__VALUE="true"
export SOME_COUNT="100"
export IGNORE_ME="ignored"
```

Using the middleware:

```clojure
(def config (configurer (resources "config.edn") [(senv/load-system-env)])
(config :vault-token) ;; => "top secret"
(config :a :nested :value) ;; => true    <- Converted to a boolean value
(config :some-count) ;; => 100    <- Converted to a number
(config :ignore-me) ;; => WARNING: (:ignore-me) isn't a valid config
```

I can't add reviewers so **cc** @ddillinger @leathekd @mindbat 